### PR TITLE
Fix missing ''package:command-name'' in mezzio config

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -74,7 +74,7 @@ class ConfigProvider
     {
         return [
             'commands' => [
-                Command\MyCommand::class,
+                'package:command-name' => Command\MyCommand::class,
             ],
         ];    
     }


### PR DESCRIPTION
Documentation fix in intro

|    Q          |   A
|-------------- | ------
| Documentation | yes

