### PR TITLE
Adds ability to mark parameters as multi-value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 - Provides the ability to chain multiple commands; see the [command chains documentation](https://docs.laminas.dev/laminas-cli/command-chains/) for more information.
 
-- Provides the ability to define input "parameters"; these act like input options with the additional behavior that, in interactive mode, if the value is not supplied, the application prompts the user interactively for the value. See the [command params documentation](https://docs.laminas.dev/laminas-cli/command-params/) for more information.
+- Provides the ability to define input "parameters"; these act like input options with the additional behavior that, in interactive mode, if the value is not supplied, the application prompts the user interactively for the value.  Parameters may accept multiple values, either via repeated option invocations, or by prompting. See the [command params documentation](https://docs.laminas.dev/laminas-cli/command-params/) for more information.
 
 ### Changed
 

--- a/docs/book/command-params.md
+++ b/docs/book/command-params.md
@@ -89,10 +89,9 @@ The constructor has one required parameter, a `string $name`; you will need to
 call `parent::__construct($name)` if you override the constructor (e.g., to
 supply other required arguments).
 
-Another trait, `Laminas\Cli\Input\StandardQuestionTrait`, provides
-the method `createQuestion()`, which returns a
-`Symfony\Component\Console\Question\Question` instance with a prompt in the form
-of:
+A trait, `Laminas\Cli\Input\StandardQuestionTrait`, provides the method
+`createQuestion()`, which returns a `Symfony\Component\Console\Question\Question`
+instance with a prompt in the form of:
 
 ```text
 <question>{description}</question> [<comment>{default}</comment>]:
@@ -104,6 +103,11 @@ things such as [normalizers](https://symfony.com/doc/current/components/console/
 [validators](https://symfony.com/doc/current/components/console/helpers/questionhelper.html#validating-the-answer),
 or [autocompletion](https://symfony.com/doc/current/components/console/helpers/questionhelper.html#autocompletion).
 
+Additionally, when the option mode includes `InputOption::VALUE_IS_ARRAY`, the
+application will prompt for multiple values using the same question and default
+value (if a default is available) until the user presses `Return` without
+entering anything.
+
 You can compose this trait in your own input param implementations, and call it
 from your `getQuestion()` method if that question format will work for you.
 
@@ -112,6 +116,9 @@ from your `getQuestion()` method if that question format will work for you.
 We ship several standard input parameter types for use in your applications. All
 parameters require the parameter name as the initial argument, and additional
 arguments as specified below.
+
+All parameter types EXCEPT the `BoolParam` allow you to specify
+`InputOption::VALUE_IS_ARRAY` as part of the option mode.
 
 ### BoolParam
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,4 +18,7 @@
 
     <!-- Include all rules from Laminas Coding Standard -->
     <rule ref="LaminasCodingStandard" />
+    <rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments.CommentForbidden">
+        <exclude name="SlevomatCodingStandard.Commenting.ForbiddenComments.CommentForbidden"/>
+    </rule>
 </ruleset>

--- a/src/Input/AbstractInputParam.php
+++ b/src/Input/AbstractInputParam.php
@@ -14,7 +14,6 @@ use InvalidArgumentException;
 use Symfony\Component\Console\Input\InputOption;
 
 use function array_walk;
-use function in_array;
 use function is_array;
 use function is_string;
 use function sprintf;
@@ -23,24 +22,30 @@ use function trim;
 /**
  * Provide the majority of methods needed to implement InputParamInterface.
  *
- * This trait provides definitions for all but the following methods of the
+ * This class provides definitions for all but the following methods of the
  * InputParamInterface:
  *
- * - getOptionMode()
  * - getQuestion()
  *
- * Additionally, it defines the `$name` property, allowing implementations to
- * set it in their constructors without needing to define the property
- * themselves.
+ * Implementations MUST call `parent::__construct()` with the name if overriding
+ * the constructor.
+ *
+ * If an option mode other than InputOption::VALUE_REQUIRED is desired,
+ * implementations should set the value themselves. NOTE: compose the
+ * AllowMultipleTrait and use its `setAllowMultipleFlag()` if multiple values
+ * can be accepted, but are not required.
  */
 abstract class AbstractInputParam implements InputParamInterface
 {
-    /** @var int[] */
-    private $allowedModes = [
-        InputOption::VALUE_NONE,
-        InputOption::VALUE_REQUIRED,
-        InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
-    ];
+    /**
+     * InputOption mode to use with this parameter.
+     *
+     * Protected, so that extending classes can change the value (e.g., via the
+     * AllowMultipleTrait).
+     *
+     * @var int
+     */
+    protected $optionMode = InputOption::VALUE_REQUIRED;
 
     /** @var mixed */
     private $default;
@@ -54,13 +59,6 @@ abstract class AbstractInputParam implements InputParamInterface
      * @var string
      */
     private $name;
-
-    /**
-     * InputOption mode to use with this parameter.
-     *
-     * @var int
-     */
-    private $optionMode = InputOption::VALUE_REQUIRED;
 
     /** @var bool */
     private $required = false;
@@ -123,19 +121,6 @@ abstract class AbstractInputParam implements InputParamInterface
     public function setDescription(string $description): InputParamInterface
     {
         $this->description = $description;
-        return $this;
-    }
-
-    public function setOptionMode(int $mode): InputParamInterface
-    {
-        if (! in_array($mode, $this->allowedModes, true)) {
-            throw new InvalidArgumentException(sprintf(
-                'Invalid option mode; must be one of %s::VALUE_NONE,'
-                . ' VALUE_REQUIRED, or VALUE_REQUIRED | VALUE_IS_ARRAY',
-                InputOption::class
-            ));
-        }
-        $this->optionMode = $mode;
         return $this;
     }
 

--- a/src/Input/AbstractParamAwareInput.php
+++ b/src/Input/AbstractParamAwareInput.php
@@ -261,7 +261,7 @@ abstract class AbstractParamAwareInput implements ParamAwareInputInterface
             $value = $this->helper->ask($this, $this->output, $question);
 
             if ($valueIsRequired && [] === $values) {
-                $question->setValidator(function ($value) use ($validator) {
+                $question->setValidator(static function ($value) use ($validator) {
                     if (null === $value || '' === $value) {
                         return $value;
                     }

--- a/src/Input/AllowMultipleTrait.php
+++ b/src/Input/AllowMultipleTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cli for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cli/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cli/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Cli\Input;
+
+use Symfony\Component\Console\Input\InputOption;
+
+trait AllowMultipleTrait
+{
+    /**
+     * Update the option mode to dis/allow multiple values.
+     *
+     * When enabled, the parameter will allow passing multiple options on the
+     * command line, or, if none are provided, prompt multiple times for them.
+     */
+    public function setAllowMultipleFlag(bool $flag): self
+    {
+        if ($flag) {
+            $this->optionMode |= InputOption::VALUE_IS_ARRAY;
+            return $this;
+        }
+
+        $this->optionMode ^= InputOption::VALUE_IS_ARRAY;
+        return $this;
+    }
+}

--- a/src/Input/BoolParam.php
+++ b/src/Input/BoolParam.php
@@ -21,7 +21,7 @@ final class BoolParam extends AbstractInputParam
     public function __construct(string $name)
     {
         parent::__construct($name);
-        $this->setOptionMode(InputOption::VALUE_NONE);
+        $this->optionMode = InputOption::VALUE_NONE;
     }
 
     public function getQuestion(): Question

--- a/src/Input/ChoiceParam.php
+++ b/src/Input/ChoiceParam.php
@@ -20,6 +20,8 @@ use function sprintf;
 
 final class ChoiceParam extends AbstractInputParam
 {
+    use AllowMultipleTrait;
+
     /** @var array */
     private $haystack;
 

--- a/src/Input/ChoiceParam.php
+++ b/src/Input/ChoiceParam.php
@@ -10,9 +10,12 @@ declare(strict_types=1);
 
 namespace Laminas\Cli\Input;
 
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\Question;
 
+use function implode;
+use function is_array;
 use function sprintf;
 
 final class ChoiceParam extends AbstractInputParam
@@ -33,12 +36,21 @@ final class ChoiceParam extends AbstractInputParam
     {
         $defaultValue  = $this->getDefault();
         $defaultPrompt = $defaultValue !== null
-            ? sprintf(' [<comment>%s</comment>]', $defaultValue)
+            ? sprintf(
+                ' [<comment>%s</comment>]',
+                is_array($defaultValue) ? implode(', ', $defaultValue) : $defaultValue
+            )
             : '';
+        $multiPrompt   = sprintf(
+            "\n(Multiple selections allowed; hit Return after each.%s Hit Return to stop prompting)\n",
+            $this->isRequired() ? ' At least one selection is required.' : ''
+        );
+
         return new ChoiceQuestion(
             sprintf(
-                '<question>%s?</question>%s',
+                '<question>%s?</question>%s%s',
                 $this->getDescription(),
+                $this->getOptionMode() & InputOption::VALUE_IS_ARRAY ? $multiPrompt : '',
                 $defaultPrompt
             ),
             $this->haystack,

--- a/src/Input/InputParamInterface.php
+++ b/src/Input/InputParamInterface.php
@@ -51,13 +51,6 @@ interface InputParamInterface
     public function setDescription(string $description): InputParamInterface;
 
     /**
-     * @param int $mode MUST BE one of the InputOption::VALUE_* constants, or a
-     *     bitmask of them.
-     * @return $this
-     */
-    public function setOptionMode(int $mode): InputParamInterface;
-
-    /**
      * @param null|string|string[] $shortcut One of (a) a string with a single
      *     shortcut, (b) a string with multiple shortcuts separated by a "|"
      *     character, or (c) an array of shortcuts.

--- a/src/Input/IntParam.php
+++ b/src/Input/IntParam.php
@@ -20,6 +20,7 @@ use function sprintf;
 
 final class IntParam extends AbstractInputParam
 {
+    use AllowMultipleTrait;
     use StandardQuestionTrait;
 
     /** @var null|int */

--- a/src/Input/PathParam.php
+++ b/src/Input/PathParam.php
@@ -27,6 +27,7 @@ use function sprintf;
 
 final class PathParam extends AbstractInputParam
 {
+    use AllowMultipleTrait;
     use StandardQuestionTrait;
 
     public const TYPE_DIR  = 'dir';

--- a/src/Input/StandardQuestionTrait.php
+++ b/src/Input/StandardQuestionTrait.php
@@ -10,8 +10,11 @@ declare(strict_types=1);
 
 namespace Laminas\Cli\Input;
 
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\Question;
 
+use function implode;
+use function is_array;
 use function sprintf;
 
 use const PHP_EOL;
@@ -44,13 +47,21 @@ trait StandardQuestionTrait
     {
         $defaultValue  = $this->getDefault();
         $defaultPrompt = $defaultValue !== null
-            ? sprintf(' [<comment>%s</comment>]', $defaultValue)
+            ? sprintf(
+                ' [<comment>%s</comment>]',
+                is_array($defaultValue) ? implode(', ', $defaultValue) : $defaultValue
+            )
             : '';
+        $multiPrompt   = sprintf(
+            "\n(Multiple entries allowed; hit Return after each.%s Hit Return to stop prompting)\n",
+            $this->isRequired() ? ' At least one entry is required.' : ''
+        );
 
         return new Question(
             sprintf(
-                '<question>%s:</question>%s%s > ',
+                '<question>%s:</question>%s%s%s > ',
                 $this->getDescription(),
+                $this->getOptionMode() & InputOption::VALUE_IS_ARRAY ? $multiPrompt : '',
                 $defaultPrompt,
                 PHP_EOL
             ),
@@ -62,4 +73,8 @@ trait StandardQuestionTrait
     abstract public function getDefault();
 
     abstract public function getDescription(): string;
+
+    abstract public function getOptionMode(): int;
+
+    abstract public function isRequired(): bool;
 }

--- a/src/Input/StringParam.php
+++ b/src/Input/StringParam.php
@@ -26,6 +26,7 @@ use const E_WARNING;
 
 final class StringParam extends AbstractInputParam
 {
+    use AllowMultipleTrait;
     use StandardQuestionTrait;
 
     /** @var null|string */

--- a/test/Input/AbstractInputParamTest.php
+++ b/test/Input/AbstractInputParamTest.php
@@ -14,7 +14,6 @@ use InvalidArgumentException;
 use Laminas\Cli\Input\AbstractInputParam;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Question\Question;
 
 class AbstractInputParamTest extends TestCase
@@ -60,43 +59,6 @@ class AbstractInputParamTest extends TestCase
     public function testCanRetrieveName(): void
     {
         $this->assertSame('test', $this->param->getName());
-    }
-
-    public function invalidOptionModes(): iterable
-    {
-        yield 'negative'          => [-1];
-        yield 'zero'              => [0];
-        yield 'out of range'      => [16];
-        yield 'multiple none'     => [InputOption::VALUE_NONE | InputOption::VALUE_IS_ARRAY];
-        yield 'optional'          => [InputOption::VALUE_OPTIONAL];
-        yield 'multiple optional' => [InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY];
-        yield 'multiple only'     => [InputOption::VALUE_IS_ARRAY];
-    }
-
-    /**
-     * @dataProvider invalidOptionModes
-     */
-    public function testSetOptionModeRaisesExceptionForInvalidModes(int $mode): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid option mode');
-        $this->param->setOptionMode($mode);
-    }
-
-    public function validOptionModes(): iterable
-    {
-        yield 'none'              => [InputOption::VALUE_NONE];
-        yield 'required'          => [InputOption::VALUE_REQUIRED];
-        yield 'multiple required' => [InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY];
-    }
-
-    /**
-     * @dataProvider validOptionModes
-     */
-    public function testAllowsSettingValidOptionModeCombinations(int $mode): void
-    {
-        $this->param->setOptionMode($mode);
-        $this->assertSame($mode, $this->param->getOptionMode());
     }
 
     public function testNotRequiredByDefault(): void

--- a/test/Input/ChoiceParamTest.php
+++ b/test/Input/ChoiceParamTest.php
@@ -77,9 +77,10 @@ class ChoiceParamTest extends TestCase
         );
     }
 
-    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueIsArrayButNotRequired(): void
+    // phpcs:ignore Generic.Files.LineLength.TooLong
+    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueAllowsMultipleButNotRequired(): void
     {
-        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(true);
         $this->param->setRequiredFlag(false);
         $question = $this->param->getQuestion();
         self::assertStringContainsString(
@@ -92,9 +93,9 @@ class ChoiceParamTest extends TestCase
         );
     }
 
-    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueIsArrayAndIsRequired(): void
+    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueAllowsMultipleAndIsRequired(): void
     {
-        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(true);
         $this->param->setRequiredFlag(true);
         $question = $this->param->getQuestion();
         self::assertStringContainsString(
@@ -105,5 +106,13 @@ class ChoiceParamTest extends TestCase
             'At least one selection is required. ',
             $question->getQuestion()
         );
+    }
+
+    public function testCallingSetAllowMultipleWithBooleanFalseAfterPreviouslyCallingItWithTrueRemovesOptionFlag(): void
+    {
+        $this->param->setAllowMultipleFlag(true);
+        self::assertSame(InputOption::VALUE_IS_ARRAY, $this->param->getOptionMode() & InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(false);
+        self::assertSame(0, $this->param->getOptionMode() & InputOption::VALUE_IS_ARRAY);
     }
 }

--- a/test/Input/ChoiceParamTest.php
+++ b/test/Input/ChoiceParamTest.php
@@ -67,4 +67,43 @@ class ChoiceParamTest extends TestCase
         $this->assertEquals($expectedQuestionText, $question->getQuestion());
         $this->assertSame($this->choices, $question->getChoices());
     }
+
+    public function testQuestionCreatedDoesNotIndicateMultiPromptByDefault(): void
+    {
+        $question = $this->param->getQuestion();
+        self::assertStringNotContainsString(
+            'Multiple selections allowed',
+            $question->getQuestion()
+        );
+    }
+
+    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueIsArrayButNotRequired(): void
+    {
+        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setRequiredFlag(false);
+        $question = $this->param->getQuestion();
+        self::assertStringContainsString(
+            'Multiple selections allowed',
+            $question->getQuestion()
+        );
+        self::assertStringNotContainsString(
+            'At least one selection is required. ',
+            $question->getQuestion()
+        );
+    }
+
+    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueIsArrayAndIsRequired(): void
+    {
+        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setRequiredFlag(true);
+        $question = $this->param->getQuestion();
+        self::assertStringContainsString(
+            'Multiple selections allowed',
+            $question->getQuestion()
+        );
+        self::assertStringContainsString(
+            'At least one selection is required. ',
+            $question->getQuestion()
+        );
+    }
 }

--- a/test/Input/IntParamTest.php
+++ b/test/Input/IntParamTest.php
@@ -162,4 +162,43 @@ class IntParamTest extends TestCase
 
         $this->assertSame(5, $validator(5));
     }
+
+    public function testQuestionCreatedDoesNotIndicateMultiPromptByDefault(): void
+    {
+        $question = $this->param->getQuestion();
+        self::assertStringNotContainsString(
+            'Multiple entries allowed',
+            $question->getQuestion()
+        );
+    }
+
+    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueIsArrayButNotRequired(): void
+    {
+        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setRequiredFlag(false);
+        $question = $this->param->getQuestion();
+        self::assertStringContainsString(
+            'Multiple entries allowed',
+            $question->getQuestion()
+        );
+        self::assertStringNotContainsString(
+            'At least one entry is required. ',
+            $question->getQuestion()
+        );
+    }
+
+    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueIsArrayAndIsRequired(): void
+    {
+        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setRequiredFlag(true);
+        $question = $this->param->getQuestion();
+        self::assertStringContainsString(
+            'Multiple entries allowed',
+            $question->getQuestion()
+        );
+        self::assertStringContainsString(
+            'At least one entry is required. ',
+            $question->getQuestion()
+        );
+    }
 }

--- a/test/Input/IntParamTest.php
+++ b/test/Input/IntParamTest.php
@@ -172,9 +172,10 @@ class IntParamTest extends TestCase
         );
     }
 
-    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueIsArrayButNotRequired(): void
+    // phpcs:ignore Generic.Files.LineLength.TooLong
+    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueAllowsMultipleButNotRequired(): void
     {
-        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(true);
         $this->param->setRequiredFlag(false);
         $question = $this->param->getQuestion();
         self::assertStringContainsString(
@@ -187,9 +188,9 @@ class IntParamTest extends TestCase
         );
     }
 
-    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueIsArrayAndIsRequired(): void
+    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueAllowsMultipleAndIsRequired(): void
     {
-        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(true);
         $this->param->setRequiredFlag(true);
         $question = $this->param->getQuestion();
         self::assertStringContainsString(
@@ -200,5 +201,13 @@ class IntParamTest extends TestCase
             'At least one entry is required. ',
             $question->getQuestion()
         );
+    }
+
+    public function testCallingSetAllowMultipleWithBooleanFalseAfterPreviouslyCallingItWithTrueRemovesOptionFlag(): void
+    {
+        $this->param->setAllowMultipleFlag(true);
+        self::assertSame(InputOption::VALUE_IS_ARRAY, $this->param->getOptionMode() & InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(false);
+        self::assertSame(0, $this->param->getOptionMode() & InputOption::VALUE_IS_ARRAY);
     }
 }

--- a/test/Input/ParamAwareInputTest.php
+++ b/test/Input/ParamAwareInputTest.php
@@ -28,7 +28,6 @@ use stdClass;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\StreamableInputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
@@ -80,7 +79,7 @@ class ParamAwareInputTest extends TestCase
             'multi-int-with-default' => (new IntParam('multi-int-with-default'))
                 ->setDescription('Allowed integers')
                 ->setDefault([1, 2])
-                ->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY),
+                ->setAllowMultipleFlag(true),
         ];
     }
 

--- a/test/Input/PathParamTest.php
+++ b/test/Input/PathParamTest.php
@@ -154,4 +154,43 @@ class PathParamTest extends TestCase
         $this->expectExceptionMessage('Invalid type provided');
         new PathParam('test', 'not-a-valid-type');
     }
+
+    public function testQuestionCreatedDoesNotIndicateMultiPromptByDefault(): void
+    {
+        $question = $this->param->getQuestion();
+        self::assertStringNotContainsString(
+            'Multiple entries allowed',
+            $question->getQuestion()
+        );
+    }
+
+    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueIsArrayButNotRequired(): void
+    {
+        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setRequiredFlag(false);
+        $question = $this->param->getQuestion();
+        self::assertStringContainsString(
+            'Multiple entries allowed',
+            $question->getQuestion()
+        );
+        self::assertStringNotContainsString(
+            'At least one entry is required. ',
+            $question->getQuestion()
+        );
+    }
+
+    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueIsArrayAndIsRequired(): void
+    {
+        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setRequiredFlag(true);
+        $question = $this->param->getQuestion();
+        self::assertStringContainsString(
+            'Multiple entries allowed',
+            $question->getQuestion()
+        );
+        self::assertStringContainsString(
+            'At least one entry is required. ',
+            $question->getQuestion()
+        );
+    }
 }

--- a/test/Input/PathParamTest.php
+++ b/test/Input/PathParamTest.php
@@ -164,9 +164,10 @@ class PathParamTest extends TestCase
         );
     }
 
-    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueIsArrayButNotRequired(): void
+    // phpcs:ignore Generic.Files.LineLength.TooLong
+    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueAllowsMultipleButNotRequired(): void
     {
-        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(true);
         $this->param->setRequiredFlag(false);
         $question = $this->param->getQuestion();
         self::assertStringContainsString(
@@ -179,9 +180,9 @@ class PathParamTest extends TestCase
         );
     }
 
-    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueIsArrayAndIsRequired(): void
+    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueAllowsMultipleAndIsRequired(): void
     {
-        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(true);
         $this->param->setRequiredFlag(true);
         $question = $this->param->getQuestion();
         self::assertStringContainsString(
@@ -192,5 +193,13 @@ class PathParamTest extends TestCase
             'At least one entry is required. ',
             $question->getQuestion()
         );
+    }
+
+    public function testCallingSetAllowMultipleWithBooleanFalseAfterPreviouslyCallingItWithTrueRemovesOptionFlag(): void
+    {
+        $this->param->setAllowMultipleFlag(true);
+        self::assertSame(InputOption::VALUE_IS_ARRAY, $this->param->getOptionMode() & InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(false);
+        self::assertSame(0, $this->param->getOptionMode() & InputOption::VALUE_IS_ARRAY);
     }
 }

--- a/test/Input/StringParamTest.php
+++ b/test/Input/StringParamTest.php
@@ -112,4 +112,43 @@ class StringParamTest extends TestCase
 
         $this->param->setPattern('This is#^ NOT** a! pattern,');
     }
+
+    public function testQuestionCreatedDoesNotIndicateMultiPromptByDefault(): void
+    {
+        $question = $this->param->getQuestion();
+        self::assertStringNotContainsString(
+            'Multiple entries allowed',
+            $question->getQuestion()
+        );
+    }
+
+    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueIsArrayButNotRequired(): void
+    {
+        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setRequiredFlag(false);
+        $question = $this->param->getQuestion();
+        self::assertStringContainsString(
+            'Multiple entries allowed',
+            $question->getQuestion()
+        );
+        self::assertStringNotContainsString(
+            'At least one entry is required. ',
+            $question->getQuestion()
+        );
+    }
+
+    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueIsArrayAndIsRequired(): void
+    {
+        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setRequiredFlag(true);
+        $question = $this->param->getQuestion();
+        self::assertStringContainsString(
+            'Multiple entries allowed',
+            $question->getQuestion()
+        );
+        self::assertStringContainsString(
+            'At least one entry is required. ',
+            $question->getQuestion()
+        );
+    }
 }

--- a/test/Input/StringParamTest.php
+++ b/test/Input/StringParamTest.php
@@ -122,9 +122,10 @@ class StringParamTest extends TestCase
         );
     }
 
-    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueIsArrayButNotRequired(): void
+    // phpcs:ignore Generic.Files.LineLength.TooLong
+    public function testQuestionCreatedIncludesMultiPromptButNotRequiredPromptWhenValueAllowsMultipleButNotRequired(): void
     {
-        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(true);
         $this->param->setRequiredFlag(false);
         $question = $this->param->getQuestion();
         self::assertStringContainsString(
@@ -137,9 +138,9 @@ class StringParamTest extends TestCase
         );
     }
 
-    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueIsArrayAndIsRequired(): void
+    public function testQuestionCreatedIncludesMultiPromptAndRequiredPromptWhenValueAllowsMultipleAndIsRequired(): void
     {
-        $this->param->setOptionMode(InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(true);
         $this->param->setRequiredFlag(true);
         $question = $this->param->getQuestion();
         self::assertStringContainsString(
@@ -150,5 +151,13 @@ class StringParamTest extends TestCase
             'At least one entry is required. ',
             $question->getQuestion()
         );
+    }
+
+    public function testCallingSetAllowMultipleWithBooleanFalseAfterPreviouslyCallingItWithTrueRemovesOptionFlag(): void
+    {
+        $this->param->setAllowMultipleFlag(true);
+        self::assertSame(InputOption::VALUE_IS_ARRAY, $this->param->getOptionMode() & InputOption::VALUE_IS_ARRAY);
+        $this->param->setAllowMultipleFlag(false);
+        self::assertSame(0, $this->param->getOptionMode() & InputOption::VALUE_IS_ARRAY);
     }
 }


### PR DESCRIPTION
In symfony/console, you can provide a "mode" to options, which is generally one of "none" or "required". However, you can also mask "required" values with a mode indicating the option is an array; in this scenario, the user can supply the option multiple times, and the aggregate is presented as an array when the command retrieves the option value.

Since parameters are essentially options with the ability to prompt for values if they were not provided, this patch adds support for that mode.

The support is added at the `AbstractParamAwareInput` level, when calling `getParam()`. The class now has logic to determine if the mode indicates an array of values, and if so, it will then prompt repeatedly until an empty line (i.e., user presses "return") is provided. If the value is not required, the user can press "return" immediately; otherwise, they will be prompted until at least one value is provided.

The various questions created have been updated to provide information to the user indicating that multiple values may be entered, and also to let them know when a value MUST be entered (i.e., parameter is required).

I have tests for all functionality, which were guided by actual usage within an application (where I was able to determine what did and did not work.)

Fixes #23