### PR TITLE
Final preparations before 0.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "php": "^7.3",
         "ocramius/package-versions": "^1.0",
         "psr/container": "^1.0",
-        "symfony/console": "^4.3 || ^5.0",
+        "symfony/console": "^4.3 || ^5.1.2",
         "symfony/event-dispatcher": "^4.0 || ^5.0",
         "symfony/polyfill-php80": "^1.17"
     },

--- a/docs/book/command-params.md
+++ b/docs/book/command-params.md
@@ -131,6 +131,10 @@ arguments as specified below.
 All parameter types EXCEPT the `BoolParam` compose the `AllowMultipleTrait`,
 exposing the `setAllowMultipleFlag()` flag.
 
+Additionally, when writing validators, you do not need to check if the value is
+not required and an empty value submitted;
+`ParamAwareInputInterface::getParam()` does this for you.
+
 ### BoolParam
 
 `Laminas\Cli\Input\BoolParam` allows specifying a parameter with a boolean

--- a/src/Input/IntParam.php
+++ b/src/Input/IntParam.php
@@ -42,10 +42,6 @@ final class IntParam extends AbstractInputParam
         });
 
         $question->setValidator(function ($value) {
-            if ($value === null && ! $this->isRequired()) {
-                return null;
-            }
-
             if (! is_int($value)) {
                 throw new RuntimeException(sprintf(
                     'Invalid value: integer expected, %s given',

--- a/src/Input/PathParam.php
+++ b/src/Input/PathParam.php
@@ -76,10 +76,6 @@ final class PathParam extends AbstractInputParam
         });
 
         $question->setValidator(function ($value) {
-            if ($value === null && ! $this->isRequired()) {
-                return null;
-            }
-
             if (! is_string($value)) {
                 throw new RuntimeException(sprintf('Invalid value: string expected, %s given', get_debug_type($value)));
             }

--- a/src/Input/StringParam.php
+++ b/src/Input/StringParam.php
@@ -37,10 +37,6 @@ final class StringParam extends AbstractInputParam
         $question = $this->createQuestion();
 
         $question->setValidator(function ($value) {
-            if ($value === null && ! $this->isRequired()) {
-                return null;
-            }
-
             if (! is_string($value)) {
                 throw new RuntimeException(sprintf('Invalid value: string expected, %s given', get_debug_type($value)));
             }

--- a/src/Input/TypeHintedParamAwareInput.php
+++ b/src/Input/TypeHintedParamAwareInput.php
@@ -23,11 +23,7 @@ final class TypeHintedParamAwareInput extends AbstractParamAwareInput
 {
     protected function modifyQuestion(Question $question): void
     {
-        // @todo Remove once https://github.com/symfony/symfony/issues/37046 is
-        //     addressed
-        if ($question->getMaxAttempts() === null) {
-            $question->setMaxAttempts(1000);
-        }
+        // deliberate no-op
     }
 
     // Proxy methods implementing interface

--- a/test/Input/IntParamTest.php
+++ b/test/Input/IntParamTest.php
@@ -101,12 +101,6 @@ class IntParamTest extends TestCase
         $this->assertIsCallable($validator);
     }
 
-    public function testValidatorReturnsNullIfValueIsNullAndParamIsNotRequired(): void
-    {
-        $validator = $this->param->getQuestion()->getValidator();
-        $this->assertNull($validator(null));
-    }
-
     public function testValidatorRaisesExceptionIfValueIsNullAndRequired(): void
     {
         $this->param->setRequiredFlag(true);

--- a/test/Input/PathParamTest.php
+++ b/test/Input/PathParamTest.php
@@ -75,12 +75,6 @@ class PathParamTest extends TestCase
         $this->assertIsCallable($question->getValidator());
     }
 
-    public function testValidatorReturnsNullIfValueIsNullAndParamIsNotRequired(): void
-    {
-        $validator = $this->param->getQuestion()->getValidator();
-        $this->assertNull($validator(null));
-    }
-
     public function testValidatorRaisesExceptionIfValueIsNullAndRequired(): void
     {
         $this->param->setRequiredFlag(true);

--- a/test/Input/StringParamTest.php
+++ b/test/Input/StringParamTest.php
@@ -61,12 +61,6 @@ class StringParamTest extends TestCase
         $this->assertIsCallable($validator);
     }
 
-    public function testValidatorReturnsNullIfValueIsNullAndParamIsNotRequired(): void
-    {
-        $validator = $this->param->getQuestion()->getValidator();
-        $this->assertNull($validator(null));
-    }
-
     public function testValidatorRaisesExceptionIfValueIsNullAndRequired(): void
     {
         $this->param->setRequiredFlag(true);


### PR DESCRIPTION
This patch does two final things to prepare for the 0.1.0 release:

- It bumps the symfony/console v5 requirement to 5.1.2+. This is done to make use of a [fix we requested](https://github.com/symfony/symfony/issues/37046).

- It moves the `if (null === $value && ! $this->isRequired())` guards in validators to the `AbstractParamAwareInput`. This simplifies writing validators for params.