### PR TITLE
Attempt to new the mapped command when not present in the container

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -31,14 +31,15 @@ class MyCommand extends Command
 }
 ```
 
-3. Register your command in the container:
+3. If your command has dependencies, register the command and its factory in the container. Commands that are _newable_
+without arguments can omit container configuration:
 
 ```php
 // config/autoload/dependencies.global.php:
 return [
     'dependencies' => [
-        'invokables' => [
-            MyNamespace\Command\MyCommand::class => MyNamespace\Command\MyCommand::class,
+        'factories' => [
+            MyNamespace\Command\MyCommand::class => MyNamespace\Command\MyCommandFactory::class,
         ],
     ],
 ];
@@ -85,8 +86,8 @@ class ConfigProvider
     public function getDependencyConfig() : array
     {
         return [
-            'invokables' => [
-                Command\MyCommand::class => Command\MyCommand::class,
+            'factories' => [
+                Command\MyCommand::class => Command\MyCommandFactory::class,
             ],
         ];
     }

--- a/src/AbstractContainerCommandLoader.php
+++ b/src/AbstractContainerCommandLoader.php
@@ -29,7 +29,7 @@ abstract class AbstractContainerCommandLoader implements CommandLoaderInterface
     /** @var string[] */
     private $commandMap;
 
-    public function __construct(ContainerInterface $container, array $commandMap)
+    final public function __construct(ContainerInterface $container, array $commandMap)
     {
         $this->container  = $container;
         $this->commandMap = $commandMap;

--- a/src/AbstractContainerCommandLoader.php
+++ b/src/AbstractContainerCommandLoader.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cli for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cli/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cli/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Cli;
+
+use Laminas\Cli\Exception\ConfigurationException;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
+
+use function array_keys;
+use function class_exists;
+
+/**
+ * @internal
+ */
+abstract class AbstractContainerCommandLoader implements CommandLoaderInterface
+{
+    /** @var ContainerInterface */
+    private $container;
+
+    /** @var string[] */
+    private $commandMap;
+
+    public function __construct(ContainerInterface $container, array $commandMap)
+    {
+        $this->container  = $container;
+        $this->commandMap = $commandMap;
+    }
+
+    protected function getCommand(string $name): Command
+    {
+        $command = $this->container->has($this->commandMap[$name])
+            ? $this->container->get($this->commandMap[$name])
+            : $this->createCommand($name);
+        $command->setName($name);
+
+        return $command;
+    }
+
+    protected function hasCommand(string $name): bool
+    {
+        if ($this->container->has($this->commandMap[$name])) {
+            return true;
+        }
+
+        return isset($this->commandMap[$name]);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getNames(): array
+    {
+        return array_keys($this->commandMap);
+    }
+
+    private function createCommand(string $name): Command
+    {
+        $class = $this->commandMap[$name];
+        if (! class_exists($class)) {
+            throw ConfigurationException::withInvalidMappedCommandClass($name, $class);
+        }
+
+        return new $class();
+    }
+}

--- a/src/ContainerCommandLoaderNoTypeHint.php
+++ b/src/ContainerCommandLoaderNoTypeHint.php
@@ -50,6 +50,10 @@ final class ContainerCommandLoaderNoTypeHint implements CommandLoaderInterface
      */
     public function has($name): bool
     {
+        if ($this->container->has($this->commandMap[$name])) {
+            return true;
+        }
+
         return isset($this->commandMap[$name]);
     }
 

--- a/src/ContainerCommandLoaderNoTypeHint.php
+++ b/src/ContainerCommandLoaderNoTypeHint.php
@@ -38,7 +38,9 @@ final class ContainerCommandLoaderNoTypeHint implements CommandLoaderInterface
      */
     public function get($name): Command
     {
-        $command = $this->container->get($this->commandMap[$name]);
+        $command = $this->container->has($this->commandMap[$name])
+            ? $this->container->get($this->commandMap[$name])
+            : new $this->commandMap[$name]();
         $command->setName($name);
         return $command;
     }
@@ -48,7 +50,7 @@ final class ContainerCommandLoaderNoTypeHint implements CommandLoaderInterface
      */
     public function has($name): bool
     {
-        return isset($this->commandMap[$name]) && $this->container->has($this->commandMap[$name]);
+        return isset($this->commandMap[$name]);
     }
 
     /**

--- a/src/ContainerCommandLoaderNoTypeHint.php
+++ b/src/ContainerCommandLoaderNoTypeHint.php
@@ -10,39 +10,19 @@ declare(strict_types=1);
 
 namespace Laminas\Cli;
 
-use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
-
-use function array_keys;
 
 /**
  * @internal
  */
-final class ContainerCommandLoaderNoTypeHint implements CommandLoaderInterface
+final class ContainerCommandLoaderNoTypeHint extends AbstractContainerCommandLoader
 {
-    /** @var ContainerInterface */
-    private $container;
-
-    /** @var string[] */
-    private $commandMap;
-
-    public function __construct(ContainerInterface $container, array $commandMap)
-    {
-        $this->container  = $container;
-        $this->commandMap = $commandMap;
-    }
-
     /**
      * @param string $name
      */
     public function get($name): Command
     {
-        $command = $this->container->has($this->commandMap[$name])
-            ? $this->container->get($this->commandMap[$name])
-            : new $this->commandMap[$name]();
-        $command->setName($name);
-        return $command;
+        return $this->getCommand($name);
     }
 
     /**
@@ -50,18 +30,6 @@ final class ContainerCommandLoaderNoTypeHint implements CommandLoaderInterface
      */
     public function has($name): bool
     {
-        if ($this->container->has($this->commandMap[$name])) {
-            return true;
-        }
-
-        return isset($this->commandMap[$name]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getNames(): array
-    {
-        return array_keys($this->commandMap);
+        return $this->hasCommand($name);
     }
 }

--- a/src/ContainerCommandLoaderTypeHint.php
+++ b/src/ContainerCommandLoaderTypeHint.php
@@ -44,6 +44,10 @@ final class ContainerCommandLoaderTypeHint implements CommandLoaderInterface
 
     public function has(string $name): bool
     {
+        if ($this->container->has($this->commandMap[$name])) {
+            return true;
+        }
+
         return isset($this->commandMap[$name]);
     }
 

--- a/src/ContainerCommandLoaderTypeHint.php
+++ b/src/ContainerCommandLoaderTypeHint.php
@@ -35,14 +35,16 @@ final class ContainerCommandLoaderTypeHint implements CommandLoaderInterface
 
     public function get(string $name): Command
     {
-        $command = $this->container->get($this->commandMap[$name]);
+        $command = $this->container->has($this->commandMap[$name])
+            ? $this->container->get($this->commandMap[$name])
+            : new $this->commandMap[$name]();
         $command->setName($name);
         return $command;
     }
 
     public function has(string $name): bool
     {
-        return isset($this->commandMap[$name]) && $this->container->has($this->commandMap[$name]);
+        return isset($this->commandMap[$name]);
     }
 
     /**

--- a/src/ContainerCommandLoaderTypeHint.php
+++ b/src/ContainerCommandLoaderTypeHint.php
@@ -10,52 +10,20 @@ declare(strict_types=1);
 
 namespace Laminas\Cli;
 
-use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
-
-use function array_keys;
 
 /**
  * @internal
  */
-final class ContainerCommandLoaderTypeHint implements CommandLoaderInterface
+final class ContainerCommandLoaderTypeHint extends AbstractContainerCommandLoader
 {
-    /** @var ContainerInterface */
-    private $container;
-
-    /** @var string[] */
-    private $commandMap;
-
-    public function __construct(ContainerInterface $container, array $commandMap)
+    public function has(string $name): bool
     {
-        $this->container  = $container;
-        $this->commandMap = $commandMap;
+        return $this->hasCommand($name);
     }
 
     public function get(string $name): Command
     {
-        $command = $this->container->has($this->commandMap[$name])
-            ? $this->container->get($this->commandMap[$name])
-            : new $this->commandMap[$name]();
-        $command->setName($name);
-        return $command;
-    }
-
-    public function has(string $name): bool
-    {
-        if ($this->container->has($this->commandMap[$name])) {
-            return true;
-        }
-
-        return isset($this->commandMap[$name]);
-    }
-
-    /**
-     * @return string[]
-     */
-    public function getNames(): array
-    {
-        return array_keys($this->commandMap);
+        return $this->getCommand($name);
     }
 }

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -18,7 +18,7 @@ final class ConfigurationException extends RuntimeException implements Exception
 {
     public static function withInvalidMappedCommandClass(string $commandName, string $targetClassName): self
     {
-        return new static(sprintf(
+        return new self(sprintf(
             'The target command class "%1$s" for the command named "%2$s" is not a known class and has not been '
             . 'configured with a factory. Either create a factory for "%1$s" or or alter the command to target an '
             . 'existing class',

--- a/src/Exception/ConfigurationException.php
+++ b/src/Exception/ConfigurationException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cli for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cli/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cli/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Cli\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+final class ConfigurationException extends RuntimeException implements ExceptionInterface
+{
+    public static function withInvalidMappedCommandClass(string $commandName, string $targetClassName): self
+    {
+        return new static(sprintf(
+            'The target command class "%1$s" for the command named "%2$s" is not a known class and has not been '
+            . 'configured with a factory. Either create a factory for "%1$s" or or alter the command to target an '
+            . 'existing class',
+            $targetClassName,
+            $commandName
+        ));
+    }
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cli for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cli/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cli/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Laminas\Cli\Exception;
+
+use Throwable;
+
+interface ExceptionInterface extends Throwable
+{
+}

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -524,7 +524,7 @@ class ApplicationTest extends TestCase
 
         /** @var ContainerInterface|ObjectProphecy $container */
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has(ExampleCommandWithDependencies::class)->willReturn(true);
+        $container->has(ExampleCommandWithDependencies::class)->willReturn(true)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container
             ->get(ExampleCommandWithDependencies::class)
@@ -576,7 +576,7 @@ class ApplicationTest extends TestCase
 
         /** @var ContainerInterface|ObjectProphecy $container */
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has(ExampleCommandWithDependencies::class)->willReturn(true);
+        $container->has(ExampleCommandWithDependencies::class)->willReturn(true)->shouldBeCalled();
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container
             ->get(ExampleCommandWithDependencies::class)

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -524,7 +524,7 @@ class ApplicationTest extends TestCase
 
         /** @var ContainerInterface|ObjectProphecy $container */
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has(ExampleCommandWithDependencies::class)->willReturn(true)->shouldBeCalled();
+        $container->has(ExampleCommandWithDependencies::class)->willReturn(true);
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container
             ->get(ExampleCommandWithDependencies::class)
@@ -576,7 +576,7 @@ class ApplicationTest extends TestCase
 
         /** @var ContainerInterface|ObjectProphecy $container */
         $container = $this->prophesize(ContainerInterface::class);
-        $container->has(ExampleCommandWithDependencies::class)->willReturn(true)->shouldBeCalled();
+        $container->has(ExampleCommandWithDependencies::class)->willReturn(true);
         $container->get('config')->willReturn($config)->shouldBeCalled();
         $container
             ->get(ExampleCommandWithDependencies::class)

--- a/test/ContainerCommandLoaderTest.php
+++ b/test/ContainerCommandLoaderTest.php
@@ -12,6 +12,7 @@ namespace LaminasTest\Cli;
 
 use Laminas\Cli\ContainerCommandLoader;
 use Laminas\Cli\ContainerResolver;
+use LaminasTest\Cli\TestAsset\ExampleCommand;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
@@ -59,5 +60,36 @@ class ContainerCommandLoaderTest extends TestCase
         $command = $loader->get('example:command-with-deps');
 
         self::assertInstanceOf(Command::class, $command);
+    }
+
+    public function testHasWillReturnTrueWhenTheCommandIsMappedButNotPresentInTheContainer(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects(self::never())->method('has');
+        $loader = new ContainerCommandLoader($container, [
+            'my:command' => 'CommandClassName',
+        ]);
+        self::assertTrue($loader->has('my:command'));
+    }
+
+    public function testCommandWillBeConstructedWhenNotPresentInTheContainer(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects(self::once())
+            ->method('has')
+            ->with(ExampleCommand::class)
+            ->willReturn(false);
+
+        $container->expects(self::never())
+            ->method('get')
+            ->with(ExampleCommand::class);
+
+        $loader = new ContainerCommandLoader($container, [
+            'my:command' => ExampleCommand::class,
+        ]);
+
+        $command = $loader->get('my:command');
+
+        self::assertInstanceOf(ExampleCommand::class, $command);
     }
 }

--- a/test/ContainerCommandLoaderTest.php
+++ b/test/ContainerCommandLoaderTest.php
@@ -65,10 +65,15 @@ class ContainerCommandLoaderTest extends TestCase
     public function testHasWillReturnTrueWhenTheCommandIsMappedButNotPresentInTheContainer(): void
     {
         $container = $this->createMock(ContainerInterface::class);
-        $container->expects(self::never())->method('has');
+        $container->expects(self::once())
+            ->method('has')
+            ->with('CommandClassName')
+            ->willReturn(false);
+
         $loader = new ContainerCommandLoader($container, [
             'my:command' => 'CommandClassName',
         ]);
+
         self::assertTrue($loader->has('my:command'));
     }
 


### PR DESCRIPTION
#33 :  Attempt to new mapped command names when no factory has been registered with the container

Targeting `master` because `develop` does not yet exist.

Would it be better to make this behaviour opt-in? To do that, the command loader would likely need a factory, therefore, the lib would need a config provider for the configuration flag…

Also, this impl does not attempt to discern whether the mapped command points at a new-able class with `class_exists`. Should it?