### PR TITLE
Use composer/package-versions-deprecated instead of ocramius/package-versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^7.3",
-        "ocramius/package-versions": "^1.0",
+        "composer/package-versions-deprecated": "^1.10.99",
         "psr/container": "^1.0",
         "symfony/console": "^4.3 || ^5.1.2",
         "symfony/event-dispatcher": "^4.0 || ^5.0",


### PR DESCRIPTION
To allow usage on PHP 7.3 even when Composer 2 is available.

Fixes #35