### PR TITLE
Add warning when using a third-party command in a chain

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,9 @@
         }
     },
     "autoload-dev": {
+        "files": [
+            "test/TestAsset/ThirdPartyCommand.php"
+        ],
         "psr-4": {
             "LaminasTest\\Cli\\": "test/"
         }

--- a/src/Listener/TerminateListener.php
+++ b/src/Listener/TerminateListener.php
@@ -19,6 +19,7 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use function array_search;
 use function get_class;
 use function is_array;
+use function preg_match;
 use function strtolower;
 
 use const PHP_EOL;
@@ -63,8 +64,13 @@ final class TerminateListener
             $nextCommandName = array_search($nextCommandClass, $this->config['commands'], true);
             $nextCommand     = $application->find($nextCommandName);
 
+            $thirdPartyMessage = (bool) preg_match('/^(Mezzio|Laminas)\b/', $nextCommandClass)
+                ? ''
+                : PHP_EOL . '<error>WARNING: This is a third-party command</error>';
+
             $question = new ChoiceQuestion(
                 PHP_EOL . "<info>Executing {$nextCommandName}</info> ({$nextCommand->getDescription()})."
+                . $thirdPartyMessage
                 . PHP_EOL . '<question>Do you want to continue?</question>',
                 ['Y' => 'yes, continue', 's' => 'skip command', 'n' => 'no, break'],
                 'Y'

--- a/test/Listener/TerminateListenerTest.php
+++ b/test/Listener/TerminateListenerTest.php
@@ -15,10 +15,17 @@ use LaminasTest\Cli\ApplicationTest;
 use LaminasTest\Cli\TestAsset\ExampleCommand;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Event\ConsoleTerminateEvent;
+use Symfony\Component\Console\Helper\HelperSet;
+use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use ThirdParty\Console\ThirdPartyCommand;
+
+use function preg_match;
 
 class TerminateListenerTest extends TestCase
 {
@@ -86,5 +93,79 @@ class TerminateListenerTest extends TestCase
         $event    = new ConsoleTerminateEvent($command, $this->input, $this->output, 0);
 
         $listener($event);
+    }
+
+    public function testNotifiesOfThirdPartyCommandInChain(): void
+    {
+        $listener = new TerminateListener([
+            'commands' => [
+                'example:command-name' => ExampleCommand::class,
+                'third-party:command'  => ThirdPartyCommand::class,
+            ],
+            'chains'   => [
+                ExampleCommand::class => [
+                    ThirdPartyCommand::class => [],
+                ],
+            ],
+        ]);
+
+        $thirdPartyCommand = new ThirdPartyCommand();
+        $thirdPartyCommand->configure();
+
+        $this->input
+            ->expects($this->once())
+            ->method('isInteractive')
+            ->willReturn(true);
+
+        $this->output
+            ->expects($this->once())
+            ->method('writeln')
+            ->with($this->stringContains('Break'));
+
+        $expectedChoiceQuestion = function (Question $question): bool {
+            return (bool) preg_match('#<error>.*?This is a third-party command</error>#i', $question->getQuestion());
+        };
+
+        $questionHelper = $this->createMock(QuestionHelper::class);
+        $questionHelper
+            ->expects($this->once())
+            ->method('ask')
+            ->with(
+                $this->equalTo($this->input),
+                $this->equalTo($this->output),
+                $this->callback($expectedChoiceQuestion)
+            )
+            ->willReturn('n');
+
+        $helperSet = $this->createMock(HelperSet::class);
+        $helperSet
+            ->expects($this->once())
+            ->method('get')
+            ->with($this->equalTo('question'))
+            ->willReturn($questionHelper);
+
+        $app = $this->createMock(Application::class);
+        $app
+            ->expects($this->atLeastOnce())
+            ->method('getHelperSet')
+            ->willReturn($helperSet);
+
+        $app
+            ->expects($this->once())
+            ->method('find')
+            ->with($this->equalTo('third-party:command'))
+            ->willReturn($thirdPartyCommand);
+
+        $command = new ExampleCommand();
+        $command->setApplication($app);
+
+        $event = new ConsoleTerminateEvent(
+            $command,
+            $this->input,
+            $this->output,
+            0
+        );
+
+        $this->assertNull($listener($event));
     }
 }

--- a/test/TestAsset/ThirdPartyCommand.php
+++ b/test/TestAsset/ThirdPartyCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cli for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cli/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cli/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace ThirdParty\Console;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ThirdPartyCommand extends Command
+{
+    protected static $defaultName = 'third-party:command';
+
+    public function configure(): void
+    {
+        $this->setDescription('third-party command');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        return 0;
+    }
+}


### PR DESCRIPTION
| Q           | A   |
| ----------- | --- |
| New Feature | yes |

Summary
-------

When a class with an initial namespace that is neither "Laminas" nor "Mezzio" is used, an additional message will be presented in the prompt to execute the chained command:

```text
<error>WARNING: This is a third-party command!</error>
```

Fixes #26