### PR TITLE
PHP 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,14 @@ matrix:
     - php: 7.4
       env:
         - DEPS=latest
+    - php: nightly
+      env:
+        - DEPS=lowest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: nightly
+      env:
+        - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ~8.0.0",
         "composer/package-versions-deprecated": "^1.10.99",
         "psr/container": "^1.0",
         "symfony/console": "^4.3 || ^5.1.2",
@@ -38,7 +38,7 @@
         "laminas/laminas-coding-standard": "~2.0.0",
         "laminas/laminas-mvc": "^3.1.1",
         "laminas/laminas-servicemanager": "^3.4",
-        "phpunit/phpunit": "^9.0.1",
+        "phpunit/phpunit": "^9.4.1",
         "vimeo/psalm": "^3.13"
     },
     "autoload": {

--- a/src/AbstractContainerCommandLoader.php
+++ b/src/AbstractContainerCommandLoader.php
@@ -87,7 +87,7 @@ abstract class AbstractContainerCommandLoader implements CommandLoaderInterface
     /** @psalm-param class-string<Command> $class */
     private function createCommand(string $class, string $name): Command
     {
-        /** @psalm-suppress MixedMethodCall */
+        /** @psalm-suppress UnsafeInstantiation */
         $command = new $class();
         $command->setName($name);
         return $command;

--- a/src/Input/AbstractInputParam.php
+++ b/src/Input/AbstractInputParam.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Webmozart\Assert\Assert;
 
 use function array_walk;
+use function get_debug_type;
 use function is_string;
 use function sprintf;
 use function trim;

--- a/src/Input/AbstractParamAwareInput.php
+++ b/src/Input/AbstractParamAwareInput.php
@@ -22,6 +22,7 @@ use Webmozart\Assert\Assert;
 
 use function array_map;
 use function array_walk;
+use function get_debug_type;
 use function in_array;
 use function is_array;
 use function sprintf;

--- a/test/Input/ParamAwareInputTest.php
+++ b/test/Input/ParamAwareInputTest.php
@@ -130,7 +130,7 @@ class ParamAwareInputTest extends TestCase
         yield 'hasArgument' => ['hasArgument', ['argument'], true];
         yield 'getOptions' => ['getOptions', [], ['name', 'bool', 'choices']];
         yield 'isInteractive' => ['isInteractive', [], true];
-        
+
         // Implementation-specific methods
         yield 'hasParameterOption' => ['hasParameterOption', [['some', 'values'], true], true];
         yield 'getParameterOption' => ['getParameterOption', [['some', 'values'], null, true], 'value'];
@@ -163,7 +163,7 @@ class ParamAwareInputTest extends TestCase
             $this->helper,
             $this->params
         );
-        
+
         $this->assertSame($expectedOutput, $input->$method(...$arguments));
     }
 


### PR DESCRIPTION
Signed-off-by: Oliver Peters <oliver_pet@web.de>

|    Q          |   A
|-------------- | ------
| New Feature   | yes

### Description

drop support for PHP versions < 7.3
add support for PHP 8.0
update PhpUnit to 9.4.1