### PR TITLE
Remove third-party notice for local commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#53](https://github.com/laminas/laminas-cli/pull/53) changes the behavior of `ParamInputInterface` implementations with regards to reporting third-party commands. Previously, any command not shipped via Laminas or Mezzio was flagged as a third-party command; now, commands with namespaces that do not originate in the Composer vendor directory will not be flagged as third-party commands (with the assumption that these have been developed in the target application, and are thus local).
 
 ### Deprecated
 

--- a/composer.json
+++ b/composer.json
@@ -50,10 +50,8 @@
         }
     },
     "autoload-dev": {
-        "files": [
-            "test/TestAsset/ThirdPartyCommand.php"
-        ],
         "psr-4": {
+            "Local\\": "test/TestAsset/Local/",
             "LaminasTest\\Cli\\": "test/"
         }
     },

--- a/test/TestAsset/Local/LocalCommand.php
+++ b/test/TestAsset/Local/LocalCommand.php
@@ -8,19 +8,19 @@
 
 declare(strict_types=1);
 
-namespace ThirdParty\Console;
+namespace Local;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ThirdPartyCommand extends Command
+class LocalCommand extends Command
 {
-    protected static $defaultName = 'third-party:command';
+    protected static $defaultName = 'local:command';
 
     public function configure(): void
     {
-        $this->setDescription('third-party command');
+        $this->setDescription('local command');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int


### PR DESCRIPTION
This patch provides functionality to exclude local commands (defined as anything not in the vendor directory) from resulting in a prompt warning that a third-party command is about to be executed (when executed as part of a chain).

It does so by checking if the command class is defined in the configured Composer `vendor-dir`, but not within a laminas, laminas-api-tools, or mezzio subdirectory. If it is one of those subdirectories, or not defined in the `vendor-dir`, we consider it a local command.

Fixes #44
