### PR TITLE
Allow defining an EventDispatcher service in the container

### DIFF
--- a/docs/book/events.md
+++ b/docs/book/events.md
@@ -1,44 +1,51 @@
 # Events
 
-The symfony/console component allows attaching an event dispatcher instance to a console application.
+The [symfony/console component](https://symfony.com/doc/current/components/console.html) allows attaching an event dispatcher instance to a console application.
 During the lifetime of a console command, the application will trigger a number of events, to which you may subscribe listeners.
 Internally, laminas/laminas-cli itself adds a listener on the `Symfony\Component\Console\ConsoleEvents::TERMINATE` event in order to provide [command chains](command-chains.md).
 
 If you wish to subscribe to any of the various symfony/console events, you will need to provide an alternate event dispatcher instance.
 You may do so by defining a `Laminas\Cli\SymfonyEventDispatcher` service in your container that resolves to a `Symfony\Component\EventDispatcher\EventDispatcherInterface` instance. (We use this instead of the more generic `Symfony\Contracts\EventDispatcher\EventDispatcherInterface` so that we can use its `addListener()` method to subscribe our own listener.)
 
-As an example, your container configuration file might look like the following for laminas-mvc applications:
+As an example, your container configuration file might look like the following for laminas-mvc applications.
+Create a configuration file named `config/autoload/console.global.php` if it does not already exist, and ensure the following contents are present:
 
 ```php
-// in config/autoload/console.global.php
 return [
     'service_manager' => [
         'factories' => [
             'Laminas\Cli\SymfonyEventDispatcher' => \Your\Custom\DispatcherFactory::class,
+            // ...
         ],
         'delegators' => [
-          'Laminas\Cli\SymfonyEventDispatcher' => [
-              // [OPTIONAL] Delegator factories for adding listeners and/or subscribers
-          ],
+            'Laminas\Cli\SymfonyEventDispatcher' => [
+                // [OPTIONAL] Delegator factories for adding listeners and/or subscribers
+            ],
+            // ...
         ],
+        // ...
     ],
+    // ...
 ];
 ```
 
-Or like the following for Mezzio applications:
+If you are in a Mezzio application, again, create a configuration file named `config/autoload/console.global.php` if it does not already exist, and ensure the following contents are present:
 
 ```php
-// in config/autoload/console.global.php
 return [
     'dependencies' => [
         'factories' => [
             'Laminas\Cli\SymfonyEventDispatcher' => \Your\Custom\DispatcherFactory::class,
+            // ...
         ],
         'delegators' => [
-          'Laminas\Cli\SymfonyEventDispatcher' => [
-              // [OPTIONAL] Delegator factories for adding listeners and/or subscribers
-          ],
+            'Laminas\Cli\SymfonyEventDispatcher' => [
+                // [OPTIONAL] Delegator factories for adding listeners and/or subscribers
+            ],
+            // ...
         ],
+        // ...
     ],
+    // ...
 ];
 ```

--- a/docs/book/events.md
+++ b/docs/book/events.md
@@ -1,0 +1,44 @@
+# Events
+
+The symfony/console component allows attaching an event dispatcher instance to a console application.
+During the lifetime of a console command, the application will trigger a number of events, to which you may subscribe listeners.
+Internally, laminas/laminas-cli itself adds a listener on the `Symfony\Component\Console\ConsoleEvents::TERMINATE` event in order to provide [command chains](command-chains.md).
+
+If you wish to subscribe to any of the various symfony/console events, you will need to provide an alternate event dispatcher instance.
+You may do so by defining a `Laminas\Cli\SymfonyEventDispatcher` service in your container that resolves to a `Symfony\Component\EventDispatcher\EventDispatcherInterface` instance. (We use this instead of the more generic `Symfony\Contracts\EventDispatcher\EventDispatcherInterface` so that we can use its `addListener()` method to subscribe our own listener.)
+
+As an example, your container configuration file might look like the following for laminas-mvc applications:
+
+```php
+// in config/autoload/console.global.php
+return [
+    'service_manager' => [
+        'factories' => [
+            'Laminas\Cli\SymfonyEventDispatcher' => \Your\Custom\DispatcherFactory::class,
+        ],
+        'delegators' => [
+          'Laminas\Cli\SymfonyEventDispatcher' => [
+              // [OPTIONAL] Delegator factories for adding listeners and/or subscribers
+          ],
+        ],
+    ],
+];
+```
+
+Or like the following for Mezzio applications:
+
+```php
+// in config/autoload/console.global.php
+return [
+    'dependencies' => [
+        'factories' => [
+            'Laminas\Cli\SymfonyEventDispatcher' => \Your\Custom\DispatcherFactory::class,
+        ],
+        'delegators' => [
+          'Laminas\Cli\SymfonyEventDispatcher' => [
+              // [OPTIONAL] Delegator factories for adding listeners and/or subscribers
+          ],
+        ],
+    ],
+];
+```

--- a/docs/book/events.md
+++ b/docs/book/events.md
@@ -62,6 +62,8 @@ Finally, we need to wire both our `ErrorListener` and our `EventDispatcher` serv
 We can do so by creating a configuration file named `config/autoload/console.global.php` if it does not already exist, and adding the following contents:
 
 ```php
+<?php
+
 return [
     '{CONTAINER_KEY}' => [
         'factories' => [

--- a/docs/book/events.md
+++ b/docs/book/events.md
@@ -4,7 +4,7 @@ The [symfony/console component](https://symfony.com/doc/current/components/conso
 During the lifetime of a console command, the application will trigger a number of events, to which you may subscribe listeners.
 Internally, laminas/laminas-cli itself adds a listener on the `Symfony\Component\Console\ConsoleEvents::TERMINATE` event in order to provide [command chains](command-chains.md).
 
-If you wish to subscribe to any of the various symfony/console events, you will need to provide an alternate event dispatcher instance.
+If you wish to subscribe to any of the various [symfony/console events](https://symfony.com/doc/current/components/console/events.html), you will need to provide an alternate event dispatcher instance.
 You may do so by defining a `Laminas\Cli\SymfonyEventDispatcher` service in your container that resolves to a `Symfony\Component\EventDispatcher\EventDispatcherInterface` instance. (We use this instead of the more generic `Symfony\Contracts\EventDispatcher\EventDispatcherInterface` so that we can use its `addListener()` method to subscribe our own listener.)
 
 As an example, let's say you want to register the `Symfony\Component\Console\EventListener\ErrorListener` in your console application for purposes of debugging.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
     - Command Chains: command-chains.md
     - Command Params: command-params.md
     - Autocompletion: autocompletion.md
+    - Events: events.md
 site_name: laminas-cli
 site_description: 'Command-line interface for Laminas projects'
 repo_url: 'https://github.com/laminas/laminas-cli'

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -16,6 +16,7 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Webmozart\Assert\Assert;
 
 use function strstr;
@@ -40,7 +41,12 @@ final class ApplicationFactory
         Assert::isMap($commands);
         Assert::allString($commands);
 
-        $dispatcher = new EventDispatcher();
+        $eventDispatcherServiceName = __NAMESPACE__ . '\SymfonyEventDispatcher';
+        $dispatcher                 = $container->has($eventDispatcherServiceName)
+            ? $container->get($eventDispatcherServiceName)
+            : new EventDispatcher();
+        Assert::isInstanceOf($dispatcher, EventDispatcherInterface::class);
+
         $dispatcher->addListener(ConsoleEvents::TERMINATE, new TerminateListener($config));
 
         $application = new Application('laminas', $version);

--- a/test/ApplicationFactoryTest.php
+++ b/test/ApplicationFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-cli for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-cli/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-cli/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cli;
+
+use Laminas\Cli\ApplicationFactory;
+use Laminas\Cli\Listener\TerminateListener;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\ConsoleEvents;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+
+/** @psalm-suppress PropertyNotSetInConstructor */
+class ApplicationFactoryTest extends TestCase
+{
+    public function testPullsEventDispatcherFromContainerWhenPresent(): void
+    {
+        $config = [
+            'laminas-cli' => [],
+        ];
+
+        $dispatcher = $this->createMock(EventDispatcherInterface::class);
+        $dispatcher
+            ->expects($this->once())
+            ->method('addListener')
+            ->with(
+                ConsoleEvents::TERMINATE,
+                $this->isInstanceOf(TerminateListener::class)
+            );
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container
+            ->expects($this->once())
+            ->method('has')
+            ->with('Laminas\Cli\SymfonyEventDispatcher')
+            ->willReturn(true);
+        $container
+            ->expects($this->exactly(2))
+            ->method('get')
+            ->withConsecutive(
+                ['config'],
+                ['Laminas\Cli\SymfonyEventDispatcher']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $config,
+                $dispatcher
+            );
+
+        /** @psalm-suppress InternalClass */
+        $this->assertInstanceOf(Application::class, (new ApplicationFactory())($container));
+    }
+}

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -475,7 +475,13 @@ class ApplicationTest extends TestCase
     public function testParamInputNonInteractiveMissingParameter(): void
     {
         $container = $this->createMock(ContainerInterface::class);
-        $container->method('has')->with(ParamCommand::class)->willReturn(true);
+        $container
+            ->expects($this->atLeast(2))
+            ->method('has')
+            ->willReturnMap([
+                ['Laminas\Cli\SymfonyEventDispatcher', false],
+                [ParamCommand::class, true],
+            ]);
         $container->method('get')->willReturnMap([
             [
                 'config',
@@ -528,10 +534,12 @@ class ApplicationTest extends TestCase
         /** @psalm-var ContainerInterface&\PHPUnit\Framework\MockObject\MockObject $container */
         $container = $this->createMock(ContainerInterface::class);
         $container
-            ->expects($this->atLeastOnce())
+            ->expects($this->atLeast(2))
             ->method('has')
-            ->with($this->equalTo(ExampleCommandWithDependencies::class))
-            ->willReturn(true);
+            ->willReturnMap([
+                ['Laminas\Cli\SymfonyEventDispatcher', false],
+                [ExampleCommandWithDependencies::class, true],
+            ]);
 
         $container
             ->method('get')
@@ -587,10 +595,12 @@ class ApplicationTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
 
         $container
-            ->expects($this->atLeastOnce())
+            ->expects($this->atLeast(2))
             ->method('has')
-            ->with($this->equalTo(ExampleCommandWithDependencies::class))
-            ->willReturn(true);
+            ->willReturnMap([
+                ['Laminas\Cli\SymfonyEventDispatcher', false],
+                [ExampleCommandWithDependencies::class, true],
+            ]);
 
         $container
             ->method('get')


### PR DESCRIPTION
This patch adds logic to the `ApplicationFactory` to test for a `Laminas\Cli\SymfonyEventDispatcher` instance and, if found, use it to populate the symfony/console instance (if not found, we instantiate one directly, as we did before).

We **require** that the service returned implement `Symfony\Component\EventDispatcher\EventDispatcherInterface` to ensure that we can add our `ConsoleEvents::TERMINATE` event.

Users who want to supply additional listeners or subscribers can do so by defining the service and optionally adding delegators to it.

Fixes #47
