### PR TITLE
Perform QA improvements for PHPUnit and Psalm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.phpcs-cache
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "laminas/laminas-mvc": "^3.1.1",
         "laminas/laminas-servicemanager": "^3.4",
         "phpunit/phpunit": "^9.4.1",
-        "vimeo/psalm": "^3.13"
+        "vimeo/psalm": "^4.4.1"
     },
     "autoload": {
         "files": [

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="./vendor/autoload.php"
-         colors="true">
+    xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+    bootstrap="./vendor/autoload.php"
+    colors="true">
+    <coverage>
+        <include>
+            <directory suffix=".php">./src</directory>
+        </include>
+
+        <exclude>
+            <file>./src/autoload.php</file>
+        </exclude>
+    </coverage>
+
     <testsuites>
         <testsuite name="laminas-cli">
             <directory>./test/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./src</directory>
-            <exclude>
-                <file>./src/autoload.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="4.4.1@9fd7a7d885b3a216cff8dec9d8c21a132f275224">
+  <file src="src/Input/AbstractInputParam.php">
+    <LessSpecificImplementedReturnType occurrences="1">
+      <code>InputParamInterface</code>
+    </LessSpecificImplementedReturnType>
+  </file>
+  <file src="src/Input/AbstractParamAwareInput.php">
+    <ImplementedReturnTypeMismatch occurrences="1">
+      <code>?bool</code>
+    </ImplementedReturnTypeMismatch>
+  </file>
+  <file src="test/ContainerCommandLoaderTest.php">
+    <MixedAssignment occurrences="1">
+      <code>$config</code>
+    </MixedAssignment>
+  </file>
+</files>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <file name="bin/laminas"/>

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -38,6 +38,7 @@ final class ApplicationFactory
 
         $commands = $config['commands'] ?? [];
         Assert::isMap($commands);
+        Assert::allString($commands);
 
         $dispatcher = new EventDispatcher();
         $dispatcher->addListener(ConsoleEvents::TERMINATE, new TerminateListener($config));

--- a/src/Listener/TerminateListener.php
+++ b/src/Listener/TerminateListener.php
@@ -114,7 +114,7 @@ final class TerminateListener
             $exitCode = $application->run(new ArrayInput($params), $output);
 
             if ($exitCode !== 0) {
-                $event->setExitCode((int) $exitCode);
+                $event->setExitCode($exitCode);
                 return;
             }
         }

--- a/test/Input/ParamAwareInputTest.php
+++ b/test/Input/ParamAwareInputTest.php
@@ -83,24 +83,34 @@ class ParamAwareInputTest extends TestCase
         $this->output         = $this->createMock(OutputInterface::class);
         $this->helper         = $this->createMock(QuestionHelper::class);
 
+        $stringParam = new StringParam('name');
+        $stringParam->setDescription('Your name');
+        $stringParam->setRequiredFlag(true);
+
+        $boolParam = new BoolParam('bool');
+        $boolParam->setDescription('True or false');
+        $boolParam->setRequiredFlag(true);
+
+        $choiceParam = new ChoiceParam('choices', ['a', 'b', 'c']);
+        $choiceParam->setDescription('Choose one');
+        $choiceParam->setDefault('a');
+
+        $multiIntParamWithDefault = new IntParam('multi-int-with-default');
+        $multiIntParamWithDefault->setDescription('Allowed integers');
+        $multiIntParamWithDefault->setDefault([1, 2]);
+        $multiIntParamWithDefault->setAllowMultipleFlag(true);
+
+        $multiIntParamRequired = new IntParam('multi-int-required');
+        $multiIntParamRequired->setDescription('Required integers');
+        $multiIntParamRequired->setRequiredFlag(true);
+        $multiIntParamRequired->setAllowMultipleFlag(true);
+
         $this->params = [
-            'name'                   => (new StringParam('name'))
-                ->setDescription('Your name')
-                ->setRequiredFlag(true),
-            'bool'                   => (new BoolParam('bool'))
-                ->setDescription('True or false')
-                ->setRequiredFlag(true),
-            'choices'                => (new ChoiceParam('choices', ['a', 'b', 'c']))
-                ->setDescription('Choose one')
-                ->setDefault('a'),
-            'multi-int-with-default' => (new IntParam('multi-int-with-default'))
-                ->setDescription('Allowed integers')
-                ->setDefault([1, 2])
-                ->setAllowMultipleFlag(true),
-            'multi-int-required'     => (new IntParam('multi-int-required'))
-                ->setDescription('Required integers')
-                ->setRequiredFlag(true)
-                ->setAllowMultipleFlag(true),
+            'name'                   => $stringParam,
+            'bool'                   => $boolParam,
+            'choices'                => $choiceParam,
+            'multi-int-with-default' => $multiIntParamWithDefault,
+            'multi-int-required'     => $multiIntParamRequired,
         ];
     }
 


### PR DESCRIPTION
Performs the following PHPUnit changes:

- Updates PHPUnit configuration schema to latest version.
- Adds the PHPUnit result cache to the `.gitignore` rules

In addition, it fixes a failing unit test due to changes in the most recent symfony/console versions, whereby the output formatter is now retrieved from the output instance, instead of hardcoded.  The test change checks for the presence of a `NullOutputFormatter`, and, if present, creates an instance adds an expectation to the output instance to retrieve it.

Finally, it performs a vimeo/psalm upgrade, and corrects errors flagged by the new version.