### PR TITLE
Ensure TerminateListener works correctly for null return values from commands

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -10,6 +10,14 @@
       <code>?bool</code>
     </ImplementedReturnTypeMismatch>
   </file>
+  <file src="src/Listener/TerminateListener.php">
+    <DocblockTypeContradiction occurrences="1">
+      <code>0</code>
+    </DocblockTypeContradiction>
+    <RedundantConditionGivenDocblockType occurrences="1">
+      <code>$application-&gt;run(new ArrayInput($params), $output)</code>
+    </RedundantConditionGivenDocblockType>
+  </file>
   <file src="test/ContainerCommandLoaderTest.php">
     <MixedAssignment occurrences="1">
       <code>$config</code>

--- a/src/Listener/TerminateListener.php
+++ b/src/Listener/TerminateListener.php
@@ -111,7 +111,7 @@ final class TerminateListener
             $inputMapper = $this->createInputMapper($inputMapperSpec, $nextCommandClass);
 
             $params   = ['command' => $nextCommandName] + $inputMapper($input);
-            $exitCode = $application->run(new ArrayInput($params), $output);
+            $exitCode = $application->run(new ArrayInput($params), $output) ?? 0;
 
             if ($exitCode !== 0) {
                 $event->setExitCode($exitCode);


### PR DESCRIPTION
For some reason, recent versions of symfony/console allow commands to return a `null` value instead of an int, though they document the return value as an int via docblock.  The result is that not casting the return value to an int prior to calling `setExitCode()` in the `TerminateListener` can lead to an error condition if the value is `null`.  Unfortunately, it also means that Psalm flags a redundant and/or contradiction, requiring a baseline change.
