### PR TITLE
Ensure parameter normalization occurs before validation when parameter is passed as an option during invocation

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -9,6 +9,9 @@
     <ImplementedReturnTypeMismatch occurrences="1">
       <code>?bool</code>
     </ImplementedReturnTypeMismatch>
+    <MixedAssignment occurrences="1">
+      <code>$normalizedValue</code>
+    </MixedAssignment>
   </file>
   <file src="src/Listener/TerminateListener.php">
     <DocblockTypeContradiction occurrences="1">

--- a/src/Input/AbstractParamAwareInput.php
+++ b/src/Input/AbstractParamAwareInput.php
@@ -94,8 +94,9 @@ abstract class AbstractParamAwareInput implements ParamAwareInputInterface
 
         $valueIsArray = (bool) ($inputParam->getOptionMode() & InputOption::VALUE_IS_ARRAY);
         if ($this->isParamValueProvided($inputParam, $value)) {
-            $this->validateValue($value, $valueIsArray, $question->getValidator(), $name);
-            return $this->normalizeValue($value, $valueIsArray, $question->getNormalizer());
+            $normalizedValue = $this->normalizeValue($value, $question->getNormalizer());
+            $this->validateValue($normalizedValue, $valueIsArray, $question->getValidator(), $name);
+            return $normalizedValue;
         }
 
         if (! $this->input->isInteractive() && $inputParam->isRequired()) {
@@ -213,7 +214,7 @@ abstract class AbstractParamAwareInput implements ParamAwareInputInterface
      * @param mixed $value
      * @return mixed
      */
-    private function normalizeValue($value, bool $valueIsArray, ?callable $normalizer)
+    private function normalizeValue($value, ?callable $normalizer)
     {
         // No normalizer: nothing to do
         if ($normalizer === null) {
@@ -221,12 +222,11 @@ abstract class AbstractParamAwareInput implements ParamAwareInputInterface
         }
 
         // Non-array value: normalize it directly
-        if (! $valueIsArray && ! is_array($value)) {
+        if (! is_array($value)) {
             return $normalizer($value);
         }
 
         // Array value: map each to the normalizer
-        Assert::isArray($value);
         return array_map($normalizer, $value);
     }
 


### PR DESCRIPTION
When a `Question` is asked, symfony/console performs normalizations prior to validations.  However, in `AbstractParamAwareInput::getOption()`, we were doing the opposite when the option was passed during invocation, which was leading to false negative validations.  This patch now normalizes values passed as options before validating them.

Doing so caused an existing test to fail, however.  The test was validating that an input marked as being an array of values would be marked invalid, with a specific exception message; the exception was now being thrown from an assertion during normalization.  As such, this patch removes the `Assert::isArray` from `normalizeValue()`, and instead applies normalizations without assertions, by either normalizing a non-array value, or applying normalizations to all values in an array.

Fixes #55
