### PR TITLE
Ensure unknown commands do not trigger a container lookup

### DIFF
--- a/src/AbstractContainerCommandLoader.php
+++ b/src/AbstractContainerCommandLoader.php
@@ -15,6 +15,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 use Webmozart\Assert\Assert;
 
+use function array_key_exists;
 use function array_keys;
 use function sprintf;
 
@@ -61,6 +62,10 @@ abstract class AbstractContainerCommandLoader implements CommandLoaderInterface
 
     protected function hasCommand(string $name): bool
     {
+        if (! array_key_exists($name, $this->commandMap)) {
+            return false;
+        }
+
         if ($this->container->has($this->commandMap[$name])) {
             return true;
         }

--- a/test/ContainerCommandLoaderTest.php
+++ b/test/ContainerCommandLoaderTest.php
@@ -135,4 +135,15 @@ class ContainerCommandLoaderTest extends TestCase
 
         $this->fail('An exception was not thrown');
     }
+
+    public function testLoaderReturnsFalseWhenTestingCommandThatDoesNotExist(): void
+    {
+        $container = $this->createMock(ContainerInterface::class);
+        $container->expects(self::never())
+            ->method('has');
+
+        $loader = new ContainerCommandLoader($container, []);
+
+        $this->assertFalse($loader->has('my:command'));
+    }
 }


### PR DESCRIPTION
Updates `AbstractContainerCommandLoader::hasCommand()` to test if the `$name` exists in the `$commandMap` before attempting to check the container.
If not, it immediately returns false.

Fixes #64
