### PR TITLE
bugfix: only use `--container` option definition to resolve container

### DIFF
--- a/bin/laminas
+++ b/bin/laminas
@@ -6,7 +6,7 @@ declare(strict_types=1);
 use Laminas\Cli\ApplicationProvisioner;
 use Laminas\Cli\ApplicationFactory;
 use Laminas\Cli\ContainerResolver;
-use Symfony\Component\Console\Input\ArgvInput;
+use Laminas\Cli\Input\ContainerInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
 
 if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
@@ -26,26 +26,20 @@ $projectRoot = dirname($a) . '/../';
 chdir($projectRoot);
 
 $app = (new ApplicationFactory())();
-$definition = $app->getDefinition();
 $output = new ConsoleOutput();
 $containerNotFoundMessage = '';
+
 try {
-    $input = new ArgvInput();
-    $input->bind($definition);
-    $container = (new ContainerResolver($projectRoot))->resolve($input);
+    $container = (new ContainerResolver($projectRoot))->resolve(new ContainerInput());
     $app = (new ApplicationProvisioner())($app, $container);
-} catch (\Symfony\Component\Console\Exception\RuntimeException $exception) {
-    // Running the app after suppressing container resolution exceptions allows symfony/console to report usage information
 } catch (RuntimeException | InvalidArgumentException $exception) {
     // Usage information provided by the `ContainerResolver` should be passed to the CLI output
     $containerNotFoundMessage = sprintf('<error>%s</error>', $exception->getMessage());
-} finally {
-    $input = new ArgvInput();
 }
 
 // By running the app even if its not provisioned allows symfony/console to report problems
 // and/or display available options (like `--container`)
-$exitCode = $app->run($input, $output);
+$exitCode = $app->run(null,$output);
 
 if ($containerNotFoundMessage) {
     $output->writeln($containerNotFoundMessage);

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -6,7 +6,6 @@ namespace Laminas\Cli;
 
 use PackageVersions\Versions;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Input\InputOption;
 use Webmozart\Assert\Assert;
 
 use function strstr;
@@ -20,7 +19,7 @@ use function strstr;
  */
 final class ApplicationFactory
 {
-    public const CONTAINER_OPTION = 'container';
+    public const CONTAINER_OPTION = ContainerOptionFactory::CONTAINER_OPTION;
 
     public function __invoke(): Application
     {
@@ -31,14 +30,7 @@ final class ApplicationFactory
         $application->setAutoExit(false);
 
         $definition = $application->getDefinition();
-        $definition->addOption(
-            new InputOption(
-                self::CONTAINER_OPTION,
-                null,
-                InputOption::VALUE_REQUIRED,
-                'Path to a file which returns a PSR-11 container'
-            )
-        );
+        $definition->addOption((new ContainerOptionFactory())());
 
         return $application;
     }

--- a/src/ContainerOptionFactory.php
+++ b/src/ContainerOptionFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Cli;
+
+use Symfony\Component\Console\Input\InputOption;
+
+/**
+ * @internal
+ */
+final class ContainerOptionFactory
+{
+    public const CONTAINER_OPTION = 'container';
+
+    public function __invoke(): InputOption
+    {
+        return new InputOption(
+            self::CONTAINER_OPTION,
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Path to a file which returns a PSR-11 container'
+        );
+    }
+}

--- a/src/ContainerResolver.php
+++ b/src/ContainerResolver.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Laminas\Cli;
 
 use InvalidArgumentException;
+use Laminas\Cli\Input\ContainerInputInterface;
 use Laminas\ModuleManager\ModuleManagerInterface;
 use Laminas\Mvc\Service\ServiceManagerConfig;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
 use Psr\Container\ContainerInterface;
 use RuntimeException;
-use Symfony\Component\Console\Input\InputInterface;
 use Webmozart\Assert\Assert;
 
 use function class_exists;
@@ -44,10 +44,9 @@ final class ContainerResolver
      *
      * @throws RuntimeException When cannot locate PSR-11 container for the application.
      */
-    public function resolve(InputInterface $input): ContainerInterface
+    public function resolve(ContainerInputInterface $containerInput): ContainerInterface
     {
-        $pathToContainer = $input->getOption(ApplicationFactory::CONTAINER_OPTION) ?? '';
-        Assert::string($pathToContainer);
+        $pathToContainer = $containerInput->get();
 
         if ($pathToContainer !== '') {
             if (! $this->isAbsolutePath($pathToContainer)) {

--- a/src/Input/ContainerInput.php
+++ b/src/Input/ContainerInput.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Cli\Input;
+
+use Laminas\Cli\ContainerOptionFactory;
+use Webmozart\Assert\Assert;
+
+use function array_shift;
+use function count;
+use function in_array;
+use function strpos;
+use function substr;
+
+/**
+ * @internal
+ */
+final class ContainerInput implements ContainerInputInterface
+{
+    /** @var string */
+    private $path = '';
+
+    public function __construct(?array $argv = null)
+    {
+        $args = $argv ?? $_SERVER['argv'] ?? [];
+        Assert::isList($args);
+        Assert::allString($args);
+        $this->parse($args);
+    }
+
+    public function get(): string
+    {
+        return $this->path;
+    }
+
+    /**
+     * @psalm-param list<string> $args
+     */
+    private function parse(array $args): void
+    {
+        while (null !== $token = array_shift($args)) {
+            if ('--' === $token) {
+                break;
+            }
+
+            if (0 !== strpos($token, '--')) {
+                continue;
+            }
+
+            $name = substr($token, 2);
+
+            $pos   = strpos($name, '=');
+            $value = '';
+
+            if ($pos !== false) {
+                $value = substr($name, $pos + 1);
+                $name  = substr($name, 0, $pos);
+            }
+
+            if ($name !== ContainerOptionFactory::CONTAINER_OPTION) {
+                continue;
+            }
+
+            if ($value !== '') {
+                $this->path = $value;
+                break;
+            }
+
+            if (count($args) === 0) {
+                break;
+            }
+
+            $next = array_shift($args);
+            if ((isset($next[0]) && '-' !== $next[0]) || in_array($next, ['', null], true)) {
+                $value = $next;
+            }
+
+            $this->path = $value;
+            break;
+        }
+    }
+}

--- a/src/Input/ContainerInputInterface.php
+++ b/src/Input/ContainerInputInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Cli\Input;
+
+/**
+ * @internal
+ */
+interface ContainerInputInterface
+{
+    public function get(): string;
+}

--- a/test/ContainerCommandLoaderTest.php
+++ b/test/ContainerCommandLoaderTest.php
@@ -9,11 +9,11 @@ namespace LaminasTest\Cli;
 use InvalidArgumentException;
 use Laminas\Cli\ContainerCommandLoader;
 use Laminas\Cli\ContainerResolver;
+use Laminas\Cli\Input\ContainerInputInterface;
 use LaminasTest\Cli\TestAsset\ExampleCommand;
 use LaminasTest\Cli\TestAsset\ExampleCommandWithDependencies;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
-use Symfony\Component\Console\Input\InputInterface;
 use Webmozart\Assert\Assert;
 
 /** @psalm-suppress PropertyNotSetInConstructor */
@@ -45,7 +45,7 @@ class ContainerCommandLoaderTest extends TestCase
 
     public function testGetCommandReturnsCommand(): void
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createMock(ContainerInputInterface::class);
 
         $container = (new ContainerResolver(__DIR__ . '/TestAsset'))->resolve($input);
 

--- a/test/ContainerOptionFactoryTest.php
+++ b/test/ContainerOptionFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cli;
+
+use Laminas\Cli\ContainerOptionFactory;
+use PHPUnit\Framework\TestCase;
+
+/** @psalm-suppress PropertyNotSetInConstructor */
+final class ContainerOptionFactoryTest extends TestCase
+{
+    /** @var ContainerOptionFactory */
+    private $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new ContainerOptionFactory();
+    }
+
+    public function testWillCreateInputOptionWithExpectedName(): void
+    {
+        $option = ($this->factory)();
+        self::assertEquals('container', $option->getName());
+    }
+
+    public function testWillRequireValueForOption(): void
+    {
+        $option = ($this->factory)();
+        self::assertTrue($option->isValueRequired());
+    }
+
+    public function testWontSetShortname(): void
+    {
+        $option = ($this->factory)();
+        self::assertNull($option->getShortcut());
+    }
+}

--- a/test/ContainerResolverTest.php
+++ b/test/ContainerResolverTest.php
@@ -11,13 +11,12 @@ declare(strict_types=1);
 namespace LaminasTest\Cli;
 
 use bovigo\vfs\vfsStream;
-use Laminas\Cli\ApplicationFactory;
 use Laminas\Cli\ContainerResolver;
+use Laminas\Cli\Input\ContainerInputInterface;
 use Laminas\ServiceManager\ServiceManager;
 use LaminasTest\Cli\TestAsset\ExampleDependency;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Component\Console\Input\InputInterface;
 
 use function sprintf;
 use function sys_get_temp_dir;
@@ -39,16 +38,11 @@ final class ContainerResolverTest extends TestCase
             $containerPath => $containerFileContents,
         ]);
 
-        $input = $this->createMock(InputInterface::class);
-
-        $input
-            ->expects(self::never())
-            ->method('hasOption');
+        $input = $this->createMock(ContainerInputInterface::class);
 
         $input
             ->expects(self::once())
-            ->method('getOption')
-            ->with(ApplicationFactory::CONTAINER_OPTION)
+            ->method('get')
             ->willReturn($containerPath);
 
         $projectRoot = $directory->url();
@@ -60,7 +54,7 @@ final class ContainerResolverTest extends TestCase
 
     public function testWillLoadContainerFromApplicationConfig(): void
     {
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createMock(ContainerInputInterface::class);
 
         $resolver  = new ContainerResolver(__DIR__ . '/TestAsset');
         $container = $resolver->resolve($input);
@@ -82,7 +76,7 @@ final class ContainerResolverTest extends TestCase
             ],
         ]);
 
-        $input = $this->createMock(InputInterface::class);
+        $input = $this->createMock(ContainerInputInterface::class);
 
         $projectRoot = $directory->url();
         self::assertNotSame($projectRoot, '');
@@ -105,15 +99,11 @@ final class ContainerResolverTest extends TestCase
         ]);
 
         $containerPath = sprintf('%s/%s', $directory->url(), $containerFileName);
-        $input         = $this->createMock(InputInterface::class);
-        $input
-            ->expects(self::never())
-            ->method('hasOption');
+        $input         = $this->createMock(ContainerInputInterface::class);
 
         $input
             ->expects(self::once())
-            ->method('getOption')
-            ->with(ApplicationFactory::CONTAINER_OPTION)
+            ->method('get')
             ->willReturn($containerPath);
 
         $projectRoot = $directory->url();
@@ -131,7 +121,7 @@ final class ContainerResolverTest extends TestCase
         }
 
         $resolver = new ContainerResolver($tempDirectory);
-        $input    = $this->createMock(InputInterface::class);
+        $input    = $this->createMock(ContainerInputInterface::class);
 
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('Cannot detect PSR-11 container');

--- a/test/Input/ContainerInputTest.php
+++ b/test/Input/ContainerInputTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Cli\Input;
+
+use Laminas\Cli\Input\ContainerInput;
+use PHPUnit\Framework\TestCase;
+
+final class ContainerInputTest extends TestCase
+{
+    /**
+     * @dataProvider parsableContainerOptions
+     */
+    public function testParseOptions(array $input, string $parsed): void
+    {
+        $input = new ContainerInput($input);
+
+        self::assertSame($parsed, $input->get());
+    }
+
+    public function parsableContainerOptions(): array
+    {
+        return [
+            [
+                ['laminas', '--container=bar'],
+                'bar',
+            ],
+            [
+                ['laminas', '--container', 'bar'],
+                'bar',
+            ],
+            [
+                ['laminas', '--container='],
+                '',
+            ],
+            [
+                ['laminas', '--container=', 'bar'],
+                'bar',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes
| BC Break      | yes - but only on internal classes

### Description

Using the `ArgvInput` together with the applications `InputDefinition` was a bad idea. The reason why `ArgvInput` was used was to synchronize input definition so there is no need for duplication.
Sadly, the `ArgvInput` does some kind of validation when binding the definition and as the command definition is not yet loaded, an exception is thrown.

Since we ignore that exception and skip loading the container, the application is starting up, searches for the command, cannot find any command (as container detection was skipped) and that leads to unexpected behavior.

Symfony itself ignores validation exceptions before the command itself is loaded but that wont be a solution for this library.

To avoid being interrupted by symfony while detecting the `--container` option, this PR introduces a lightweight long-options detection which focuses on detecting only the `--container` option.

closes #74
