### PR TITLE
bugfix: ignore validation of `ArgvInput`

### DIFF
--- a/bin/laminas
+++ b/bin/laminas
@@ -29,23 +29,28 @@ $app = (new ApplicationFactory())();
 $definition = $app->getDefinition();
 $output = new ConsoleOutput();
 $containerNotFoundMessage = '';
+$input = new ArgvInput();
+
 try {
-    $input = new ArgvInput();
     $input->bind($definition);
+} catch (\Symfony\Component\Console\Exception\RuntimeException $exception) {
+    // Ignore validation issues as we did not yet have the commands definition
+    // As we only need the `--container` option, we are good to go until it is passed *before* the first command argument
+    // Symfony parses the `argv` in its direct order and raises an error when more arguments or options are passed
+    // than described by the default definition.
+}
+
+try {
     $container = (new ContainerResolver($projectRoot))->resolve($input);
     $app = (new ApplicationProvisioner())($app, $container);
-} catch (\Symfony\Component\Console\Exception\RuntimeException $exception) {
-    // Running the app after suppressing container resolution exceptions allows symfony/console to report usage information
 } catch (RuntimeException | InvalidArgumentException $exception) {
     // Usage information provided by the `ContainerResolver` should be passed to the CLI output
     $containerNotFoundMessage = sprintf('<error>%s</error>', $exception->getMessage());
-} finally {
-    $input = new ArgvInput();
 }
 
 // By running the app even if its not provisioned allows symfony/console to report problems
 // and/or display available options (like `--container`)
-$exitCode = $app->run($input, $output);
+$exitCode = $app->run(null, $output);
 
 if ($containerNotFoundMessage) {
     $output->writeln($containerNotFoundMessage);


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

Ignores the validation of `ArgvInput` while detecting the `--container` option.

### Caveat

This will only work if the `--container` option is being passed before the commands name **or** right after the command name.

If the command has arguments, the `--container` option **must** be preceding the commands very first argument.

#### OK
```
$ laminas --container=<path> <command> [<argument>]
$ laminas <command> --container=<path> [<argument>]
```

#### NOK
```
$ laminas <command> <argument> --container=<path> 
```

fixes #74 