### PR TITLE
Fix mvc bootrapping

### DIFF
--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -120,6 +120,30 @@ class Module
 }
 ```
 
+### MVC Application bootstrapping
+
+Until 1.9.x laminas-cli did not bootrap the MVC Application and therefore left the Application in an unready state
+wehen executing commands via laminas-cli. (read this [Issue](https://github.com/laminas/laminas-cli/issues/106))
+
+To allow bootstrapping the MVC Application, without breaking backward compatibility, the option `'bootstrap_mvc_application'`
+was introduced. Currently it's `false` by default to not break any Apps. This might change in the future.
+
+When enabling it, make sure not to do any HTTP-Only related stuff on Module's `onBootstrap` method.
+
+```php
+// File config/application.config.php
+
+<?php
+
+return [
+    /* ... */
+    'laminas-cli' => [
+        // execute Laminas\Mvc\Application::init(), including ::boostrap() during initialization of cli app
+        'bootstrap_mvc_application' =>  true, 
+    ]
+];
+```
+
 ## Integration in Other Applications
 
 laminas-cli supports [Laminas MVC](https://github.com/laminas/laminas-mvc-skeleton)

--- a/src/ContainerResolver.php
+++ b/src/ContainerResolver.php
@@ -15,13 +15,13 @@ use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Webmozart\Assert\Assert;
 
-use const E_USER_DEPRECATED;
-
 use function class_exists;
 use function file_exists;
 use function sprintf;
 use function str_contains;
 use function trigger_error;
+
+use const E_USER_DEPRECATED;
 
 /**
  * @internal
@@ -112,7 +112,7 @@ final class ContainerResolver
             /* @deprecated MVC Application is not bootstrapped */
             trigger_error('Running laminas-cli in MVC Environment without bootstrapping '
                 . 'the MVC Application is deprecated. '
-                .'@see https://github.com/laminas/laminas-cli/issues/106', E_USER_DEPRECATED);
+                . '@see https://github.com/laminas/laminas-cli/issues/106', E_USER_DEPRECATED);
 
             $servicesConfig = $appConfig['service_manager'] ?? [];
             Assert::isMap($servicesConfig);

--- a/src/ContainerResolver.php
+++ b/src/ContainerResolver.php
@@ -15,10 +15,13 @@ use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Webmozart\Assert\Assert;
 
+use const E_USER_DEPRECATED;
+
 use function class_exists;
 use function file_exists;
 use function sprintf;
 use function str_contains;
+use function trigger_error;
 
 /**
  * @internal
@@ -107,9 +110,9 @@ final class ContainerResolver
             $serviceManager = $mvcApplication->getServiceManager();
         } else {
             /* @deprecated MVC Application is not bootstrapped */
-            trigger_error('Running laminas-cli in MVC Environment without bootstrapping ' .
-                'the MVC Application is deprecated. ' .
-                '@see https://github.com/laminas/laminas-cli/issues/106', E_USER_DEPRECATED);
+            trigger_error('Running laminas-cli in MVC Environment without bootstrapping '
+                . 'the MVC Application is deprecated. '
+                .'@see https://github.com/laminas/laminas-cli/issues/106', E_USER_DEPRECATED);
 
             $servicesConfig = $appConfig['service_manager'] ?? [];
             Assert::isMap($servicesConfig);

--- a/src/ContainerResolver.php
+++ b/src/ContainerResolver.php
@@ -6,6 +6,7 @@ namespace Laminas\Cli;
 
 use InvalidArgumentException;
 use Laminas\ModuleManager\ModuleManagerInterface;
+use Laminas\Mvc\Application;
 use Laminas\Mvc\Service\ServiceManagerConfig;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\Stdlib\ArrayUtils;
@@ -98,18 +99,31 @@ final class ContainerResolver
             Assert::isMap($appConfig);
         }
 
-        $servicesConfig = $appConfig['service_manager'] ?? [];
-        Assert::isMap($servicesConfig);
+        Assert::classExists(Application::class);
 
-        $smConfig = new ServiceManagerConfig($servicesConfig);
+        if ($appConfig['laminas-cli']['bootstrap_mvc_application'] ?? false) {
+            // initialize & bootstrap MVC Application
+            $mvcApplication = Application::init($appConfig);
+            $serviceManager = $mvcApplication->getServiceManager();
+        } else {
+            /* @deprecated MVC Application is not bootstrapped */
+            trigger_error('Running laminas-cli in MVC Environment without bootstrapping ' .
+                'the MVC Application is deprecated. ' .
+                '@see https://github.com/laminas/laminas-cli/issues/106', E_USER_DEPRECATED);
 
-        $serviceManager = new ServiceManager();
-        $smConfig->configureServiceManager($serviceManager);
-        $serviceManager->setService('ApplicationConfig', $appConfig);
+            $servicesConfig = $appConfig['service_manager'] ?? [];
+            Assert::isMap($servicesConfig);
 
-        $moduleManager = $serviceManager->get('ModuleManager');
-        Assert::isInstanceOf($moduleManager, ModuleManagerInterface::class);
-        $moduleManager->loadModules();
+            $smConfig = new ServiceManagerConfig($servicesConfig);
+
+            $serviceManager = new ServiceManager();
+            $smConfig->configureServiceManager($serviceManager);
+            $serviceManager->setService('ApplicationConfig', $appConfig);
+
+            $moduleManager = $serviceManager->get('ModuleManager');
+            Assert::isInstanceOf($moduleManager, ModuleManagerInterface::class);
+            $moduleManager->loadModules();
+        }
 
         return $serviceManager;
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | yes
| RFC           | yes/no
| QA            | yes/no

### Description

Provide option to enable MVC Application bootstrapping.

False by default, to not break any existing app.

See Issue #106 .